### PR TITLE
fix: Fix obtaining pytest test status fails after updating dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Main
 on: [push]
 
 env:
-  IMAGE_NAME: ${{ github.ref_name }}-${{ github.run_id }}
+  IMAGE_NAME: nydok-${{ github.run_id }}
 
 permissions:
   contents: read

--- a/nydok/plugin/plugin.py
+++ b/nydok/plugin/plugin.py
@@ -67,10 +67,10 @@ def pytest_runtest_call(item):
         specs_manager.add_test_case(test_case)
 
     # Run the test
-    outcome = yield
+    result = yield
 
     # Update TestCase.passed if the test passed
-    if is_pytest_with_testcase(item) and not outcome._excinfo:
+    if is_pytest_with_testcase(item) and not result.excinfo:
         test_case.passed = True
 
 


### PR DESCRIPTION
Changes to use public `excinfo` attribute rather than private `_excinfo`, not sure why the private one was used in the first place. `excinfo` is documented [here](https://docs.pytest.org/en/7.1.x/reference/reference.html?highlight=excinfo#pytest.CallInfo.excinfo).